### PR TITLE
Enable the admin_toolbar_links_access_filter module to hide menu items from Microsite Controllers 

### DIFF
--- a/localgov_microsites.info.yml
+++ b/localgov_microsites.info.yml
@@ -34,6 +34,7 @@ install:
   - drupal:views_ui
   # Contrib
   - admin_toolbar:admin_toolbar
+  - admin_toolbar:admin_toolbar_links_access_filter
   - admin_toolbar:admin_toolbar_tools
   - default_content:default_content
   - domain:domain


### PR DESCRIPTION
Part of #125