### PR TITLE
Enable new localgov_microsites_group_content module which includes Directories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "drupal/gin_login": "^1.0@RC",
         "drupal/gin_toolbar": "^1.0@beta",
         "localgovdrupal/localgov_core": "^2.1.0",
+        "localgovdrupal/localgov_directories": "^2.1",
         "localgovdrupal/localgov_subsites": "^2.0.0",
         "localgovdrupal/localgov_microsites_group": "1.x-dev",
         "localgovdrupal/localgov_microsites_base": "1.x-dev",

--- a/config/install/user.role.authenticated.yml
+++ b/config/install/user.role.authenticated.yml
@@ -9,6 +9,7 @@ dependencies:
   module:
     - filter
     - layout_paragraphs
+    - localgov_directories
     - media
     - system
 id: authenticated
@@ -19,13 +20,16 @@ permissions:
   - 'access content'
   - 'access media overview'
   - 'administer media'
+  - 'create directory facets'
   - 'create document media'
   - 'create image media'
   - 'create media'
   - 'create remote_video media'
+  - 'delete directory facets'
   - 'edit any document media'
   - 'edit any image media'
   - 'edit any remote_video media'
+  - 'edit directory facets'
   - 'edit layout paragraphs plugin config'
   - 'edit own document media'
   - 'edit own image media'
@@ -34,6 +38,7 @@ permissions:
   - 'update media'
   - 'use text format wysiwyg'
   - 'view all media revisions'
+  - 'view directory facets'
   - 'view media'
   - 'view own unpublished media'
   - 'view the administration theme'

--- a/localgov_microsites.info.yml
+++ b/localgov_microsites.info.yml
@@ -47,8 +47,8 @@ install:
   - localgov_core:localgov_media
   - localgov_microsites:localgov_microsites_media
   - localgov_microsites_colour_picker_fields:localgov_microsites_colour_picker_fields
+  - localgov_microsites_group:localgov_microsites_directories
   - localgov_microsites_group:localgov_microsites_group
-  - localgov_microsites_group:localgov_microsites_group_content
   - localgov_microsites_group:localgov_microsites_permissions
 
 themes:

--- a/localgov_microsites.info.yml
+++ b/localgov_microsites.info.yml
@@ -45,6 +45,10 @@ install:
   - twig_tweak:twig_tweak
   # LocalGov Drupal
   - localgov_core:localgov_media
+  - localgov_directories:localgov_directories
+  - localgov_directories:localgov_directories_location
+  - localgov_directories:localgov_directories_page
+  - localgov_directories:localgov_directories_venue
   - localgov_microsites:localgov_microsites_media
   - localgov_microsites_colour_picker_fields:localgov_microsites_colour_picker_fields
   - localgov_microsites_group:localgov_microsites_group

--- a/localgov_microsites.info.yml
+++ b/localgov_microsites.info.yml
@@ -45,16 +45,11 @@ install:
   - twig_tweak:twig_tweak
   # LocalGov Drupal
   - localgov_core:localgov_media
-  - localgov_directories:localgov_directories
-  - localgov_directories:localgov_directories_location
-  - localgov_directories:localgov_directories_page
-  - localgov_directories:localgov_directories_venue
   - localgov_microsites:localgov_microsites_media
   - localgov_microsites_colour_picker_fields:localgov_microsites_colour_picker_fields
   - localgov_microsites_group:localgov_microsites_group
+  - localgov_microsites_group:localgov_microsites_group_content
   - localgov_microsites_group:localgov_microsites_permissions
-  - localgov_page:localgov_page
-  - localgov_subsites:localgov_subsites
 
 themes:
   - localgov_microsites_base


### PR DESCRIPTION
The PR https://github.com/localgovdrupal/localgov_microsites_group/pull/106 creates a new localgov_microsites_group_content module which contains both Pages and Directories. This PR enables this module.

It also adds some permissions for directory facets to the authenticated user. These are required for microsite admins to manage directory facets, but is far from ideal. There's an issue for this here: #144