### PR TITLE
Fix media check on default domain

### DIFF
--- a/modules/localgov_microsites_media/localgov_microsites_media.module
+++ b/modules/localgov_microsites_media/localgov_microsites_media.module
@@ -6,8 +6,8 @@
  */
 
 use Drupal\Core\Session\AccountInterface;
-use Drupal\domain_group\DomainGroupHelper;
 use Drupal\group\Access\GroupAccessResult;
+use Drupal\group\Entity\GroupInterface;
 
 /**
  * Implements hook_ENTITY_TYPE_create_access() for node entities.
@@ -16,7 +16,15 @@ function localgov_microsites_media_node_create_access(AccountInterface $account,
 
   // Allow group users to add media items to new nodes.
   $group_id = \Drupal::service('domain_group_resolver')->getActiveDomainGroupId();
-  $group = \Drupal::entityTypeManager()->getStorage('group')->load($group_id);
-  $permission = 'create group_node:' . $entity_bundle . ' entity';
-  return GroupAccessResult::allowedIfHasGroupPermissions($group, $account, [$permission], 'AND');
+  if (empty($group_id) &&
+    ($group = \Drupal::service('current_route_match')->getParameter('group')) &&
+    ($group instanceof GroupInterface)
+  ) {
+    $group_id = $group->id();
+  }
+  if ($group_id) {
+    $group = \Drupal::entityTypeManager()->getStorage('group')->load($group_id);
+    $permission = 'create group_node:' . $entity_bundle . ' entity';
+    return GroupAccessResult::allowedIfHasGroupPermissions($group, $account, [$permission], 'AND');
+  }
 }


### PR DESCRIPTION
When the microsites controller tries to add a node on the default domain (in a group or for the control site itself):-
```
The website encountered an unexpected error. Please try again later.
AssertionError: Cannot load the "group" entity with NULL ID. in assert() (line 295 of core/lib/Drupal/Core/Entity/EntityStorageBase.php).

assert(, 'Cannot load the "group" entity with NULL ID.') (Line: 295)
Drupal\Core\Entity\EntityStorageBase->load(NULL) (Line: 19)
localgov_microsites_media_node_create_access(Object, Array, 'localgov_page')
```
Patch adds a check for group_id before loading it. Also does an attempt to pull from the path as alternative to domain as addition - would only be needed if a site admin was on the control site, but it was a quick easy add for that occasion (or if the controller is masquerading as them to do something on the control domain)