### PR TITLE
Include LocalGov Blogs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "drupal/gin": "^3.0@beta",
         "drupal/gin_login": "^1.0@RC",
         "drupal/gin_toolbar": "^1.0@beta",
+        "localgovdrupal/localgov_blogs": "1.x-dev",
         "localgovdrupal/localgov_core": "^2.1.0",
         "localgovdrupal/localgov_directories": "^2.2",
         "localgovdrupal/localgov_events": "^2.0",


### PR DESCRIPTION
This adds LocalGov Blogs integration to Microsites. It's part of 3 PRs that need to be done in order

1. https://github.com/localgovdrupal/localgov_microsites/pull/267 **(this one)**
2. https://github.com/localgovdrupal/localgov_microsites_group/pull/240
3. https://github.com/localgovdrupal/localgov_microsites/pull/268