### PR TITLE
Enable LocalGov Blogs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "drupal/gin": "^3.0@beta",
         "drupal/gin_login": "^1.0@RC",
         "drupal/gin_toolbar": "^1.0@beta",
+        "localgovdrupal/localgov_blogs": "1.x-dev",
         "localgovdrupal/localgov_core": "^2.1.0",
         "localgovdrupal/localgov_directories": "^2.2",
         "localgovdrupal/localgov_events": "^2.0",

--- a/localgov_microsites.info.yml
+++ b/localgov_microsites.info.yml
@@ -32,7 +32,7 @@ install:
   - drupal:toolbar
   - drupal:views
   - drupal:views_ui
-  
+
   # Contrib
   - admin_toolbar:admin_toolbar
   - admin_toolbar:admin_toolbar_links_access_filter
@@ -46,11 +46,12 @@ install:
   - group:group
   - group_permissions:group_permissions
   - twig_tweak:twig_tweak
-  
+
   # LocalGov Drupal
   - localgov_core:localgov_media
   - localgov_microsites:localgov_microsites_media
   - localgov_microsites_colour_picker_fields:localgov_microsites_colour_picker_fields
+  - localgov_microsites_group:localgov_microsites_blogs
   - localgov_microsites_group:localgov_microsites_directories
   - localgov_microsites_group:localgov_microsites_events
   - localgov_microsites_group:localgov_microsites_group


### PR DESCRIPTION
This adds LocalGov Blogs integration to Microsites. It's part of 3 PRs that need to be done in order

1. https://github.com/localgovdrupal/localgov_microsites/pull/267
2. https://github.com/localgovdrupal/localgov_microsites_group/pull/240
3. https://github.com/localgovdrupal/localgov_microsites/pull/268 **(this one)**