### PR TITLE
2.0.0-beta2 release

### DIFF
--- a/.github/workflows/localgov_microsites.yml
+++ b/.github/workflows/localgov_microsites.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Create LocalGov Microsites project
         run: |
-          composer create-project --stability dev --no-install localgovdrupal/localgov_microsites_project ./html "${{ matrix.localgov-version }}"
+          composer create-project --stability dev --no-install localgovdrupal/localgov_microsites_project:${LATEST_RELEASE} ./html "${{ matrix.localgov-version }}"
           composer --working-dir=./html require --no-install localgovdrupal/localgov_microsites:${{ matrix.localgov-version }}-dev
           composer --working-dir=./html require --no-install drupal/core-recommended:${{ matrix.drupal-version }} drupal/core-composer-scaffold:${{ matrix.drupal-version }} drupal/core-project-message:${{ matrix.drupal-version }} drupal/core-dev:${{ matrix.drupal-version }}
           composer --working-dir=./html install

--- a/.github/workflows/localgov_microsites.yml
+++ b/.github/workflows/localgov_microsites.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Create LocalGov Microsites project
         run: |
-          composer create-project --stability dev --no-install localgovdrupal/localgov_microsites_project:2.0.x ./html "${{ matrix.localgov-version }}"
+          composer create-project --stability dev --no-install localgovdrupal/localgov_microsites_project ./html "${{ matrix.localgov-version }}"
           composer --working-dir=./html require --no-install localgovdrupal/localgov_microsites:${{ matrix.localgov-version }}-dev
           composer --working-dir=./html require --no-install drupal/core-recommended:${{ matrix.drupal-version }} drupal/core-composer-scaffold:${{ matrix.drupal-version }} drupal/core-project-message:${{ matrix.drupal-version }} drupal/core-dev:${{ matrix.drupal-version }}
           composer --working-dir=./html install

--- a/.github/workflows/localgov_microsites.yml
+++ b/.github/workflows/localgov_microsites.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Get the latest tagged release for branch version
         run: |
           LATEST_RELEASE=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/${GIT_BASE%'.x'} | grep -Po '(?<=refs/tags/)[^"]+' | tail -1)
-          if [ -z $LATEST_RELEASE ]; then LATEST_RELEASE=2.x-dev; fi
+          if [ -z $LATEST_RELEASE ]; then LATEST_RELEASE=2.0.x-dev; fi
           echo "LATEST_RELEASE=${LATEST_RELEASE}" >> $GITHUB_ENV
 
       - name: Cached workspace

--- a/.github/workflows/localgov_microsites.yml
+++ b/.github/workflows/localgov_microsites.yml
@@ -6,10 +6,10 @@ name: Test LocalGov Microsites localgovdrupal/localgov_microsites drupal-profile
 on:
   push:
     branches:
-      - '2.x'
+      - '2.*.x'
   pull_request:
     branches:
-      - '2.x'
+      - '2.*.x'
 
 env:
   LOCALGOV_DRUPAL_PROJECT: localgovdrupal/localgov_microsites
@@ -25,9 +25,9 @@ jobs:
       fail-fast: false
       matrix:
         localgov-version:
-          - '2.x'
+          - '2.*.x'
         drupal-version:
-          - '~9.3'
+          - '~9.4'
         php-version:
           - '8.1'
 
@@ -108,9 +108,9 @@ jobs:
       fail-fast: false
       matrix:
         localgov-version:
-          - '2.x'
+          - '2.*.x'
         drupal-version:
-          - '~9.3'
+          - '~9.4'
         php-version:
           - '8.1'
 
@@ -143,9 +143,9 @@ jobs:
       fail-fast: false
       matrix:
         localgov-version:
-          - '2.x'
+          - '2.*.x'
         drupal-version:
-          - '~9.3'
+          - '~9.4'
         php-version:
           - '8.1'
 
@@ -177,9 +177,9 @@ jobs:
       fail-fast: false
       matrix:
         localgov-version:
-          - '2.x'
+          - '2.*.x'
         drupal-version:
-          - '~9.3'
+          - '~9.4'
         php-version:
           - '8.1'
 

--- a/.github/workflows/localgov_microsites.yml
+++ b/.github/workflows/localgov_microsites.yml
@@ -6,10 +6,10 @@ name: Test LocalGov Microsites localgovdrupal/localgov_microsites drupal-profile
 on:
   push:
     branches:
-      - '2.*.x'
+      - '2.0.x'
   pull_request:
     branches:
-      - '2.*.x'
+      - '2.0.x'
 
 env:
   LOCALGOV_DRUPAL_PROJECT: localgovdrupal/localgov_microsites
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         localgov-version:
-          - '2.*.x'
+          - '2.0.x'
         drupal-version:
           - '~9.4.0'
         php-version:
@@ -81,7 +81,7 @@ jobs:
 
       - name: Create LocalGov Microsites project
         run: |
-          composer create-project --stability dev --no-install localgovdrupal/localgov_microsites_project:${LATEST_RELEASE} ./html "${{ matrix.localgov-version }}"
+          composer create-project --stability dev --no-install localgovdrupal/localgov_microsites_project:2.0.x ./html "${{ matrix.localgov-version }}"
           composer --working-dir=./html require --no-install localgovdrupal/localgov_microsites:${{ matrix.localgov-version }}-dev
           composer --working-dir=./html require --no-install drupal/core-recommended:${{ matrix.drupal-version }} drupal/core-composer-scaffold:${{ matrix.drupal-version }} drupal/core-project-message:${{ matrix.drupal-version }} drupal/core-dev:${{ matrix.drupal-version }}
           composer --working-dir=./html install

--- a/.github/workflows/localgov_microsites.yml
+++ b/.github/workflows/localgov_microsites.yml
@@ -27,7 +27,7 @@ jobs:
         localgov-version:
           - '2.*.x'
         drupal-version:
-          - '~9.4'
+          - '~9.4.0'
         php-version:
           - '8.1'
 
@@ -110,7 +110,7 @@ jobs:
         localgov-version:
           - '2.*.x'
         drupal-version:
-          - '~9.4'
+          - '~9.4.0'
         php-version:
           - '8.1'
 
@@ -145,7 +145,7 @@ jobs:
         localgov-version:
           - '2.*.x'
         drupal-version:
-          - '~9.4'
+          - '~9.4.0'
         php-version:
           - '8.1'
 
@@ -179,7 +179,7 @@ jobs:
         localgov-version:
           - '2.*.x'
         drupal-version:
-          - '~9.4'
+          - '~9.4.0'
         php-version:
           - '8.1'
 

--- a/.github/workflows/localgov_microsites.yml
+++ b/.github/workflows/localgov_microsites.yml
@@ -108,7 +108,7 @@ jobs:
       fail-fast: false
       matrix:
         localgov-version:
-          - '2.*.x'
+          - '2.0.x'
         drupal-version:
           - '~9.4.0'
         php-version:
@@ -143,7 +143,7 @@ jobs:
       fail-fast: false
       matrix:
         localgov-version:
-          - '2.*.x'
+          - '2.0.x'
         drupal-version:
           - '~9.4.0'
         php-version:
@@ -177,7 +177,7 @@ jobs:
       fail-fast: false
       matrix:
         localgov-version:
-          - '2.*.x'
+          - '2.0.x'
         drupal-version:
           - '~9.4.0'
         php-version:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=8.1",
         "drupal/admin_toolbar": "^3.1",
         "drupal/autosave_form": "^1.3",
-        "drupal/core": "^9.3",
+        "drupal/core": "~9.4.0",
         "drupal/default_content": "^2.0@alpha",
         "drupal/domain_group": "dev-group-3.x#949a60ba",
         "drupal/domain_path": "1.x-dev#33fde0b",


### PR DESCRIPTION
Pull request into the release-2.0.x branch which sill support Drupal 9.4, while the release-2.1.x branch supports Drupal 9.5