### PR TITLE
Avoid using class constant as module is not installed when UI installer first reads this line.

### DIFF
--- a/src/EventSubscriber/DefaultContentImportSubscriber.php
+++ b/src/EventSubscriber/DefaultContentImportSubscriber.php
@@ -3,7 +3,6 @@
 namespace Drupal\localgov_microsites\EventSubscriber;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\default_content\Event\DefaultContentEvents;
 use Drupal\default_content\Event\ImportEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -53,7 +52,7 @@ class DefaultContentImportSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      DefaultContentEvents::IMPORT => ['onContentImport'],
+      'default_content.import'=> ['onContentImport'],
     ];
   }
 

--- a/src/EventSubscriber/DefaultContentImportSubscriber.php
+++ b/src/EventSubscriber/DefaultContentImportSubscriber.php
@@ -52,7 +52,7 @@ class DefaultContentImportSubscriber implements EventSubscriberInterface {
    */
   public static function getSubscribedEvents() {
     return [
-      'default_content.import'=> ['onContentImport'],
+      'default_content.import' => ['onContentImport'],
     ];
   }
 


### PR DESCRIPTION
To test:-
 - install via UI, check default content still works (ie when you create a group it gets the default content);
 - install via drush, and do the same check.