### PR TITLE
Adds and configures redirect module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "drupal/gin_login": "^2.0",
         "drupal/gin_toolbar": "^1.0@RC",
         "drupal/metatag": "^1.22",
+        "drupal/redirect": "^1.9",
         "localgovdrupal/localgov_blogs": "^1.0.0-beta3",
         "localgovdrupal/localgov_core": "^2.12",
         "localgovdrupal/localgov_directories": "^3.0@alpha",

--- a/localgov_microsites.info.yml
+++ b/localgov_microsites.info.yml
@@ -45,6 +45,7 @@ install:
   - metatag:metatag_open_graph
   - metatag:metatag_twitter_cards
   - require_login:require_login
+  - redirect:redirect
   - twig_tweak:twig_tweak
 
   # LocalGov Drupal

--- a/localgov_microsites.install
+++ b/localgov_microsites.install
@@ -17,7 +17,7 @@ function localgov_microsites_install() {
     'microsites_trusted_editor',
   ];
 
-  // Set 'administer redirects' permission for microsite controllers and editors.
+  // Set 'administer redirects' permission for controllers and editors.
   foreach ($role_names as $role_name) {
     $role = Role::load($role_name);
     $role->grantPermission('administer redirects');
@@ -44,7 +44,7 @@ function localgov_microsites_update_10001() {
     \Drupal::service('module_installer')->install(['redirect']);
   }
 
-  // Set 'administer redirects' permission for microsite controllers and editors.
+  // Set 'administer redirects' permission for controllers and editors.
   $role_names = [
     'microsites_controller',
     'microsites_trusted_editor',

--- a/localgov_microsites.install
+++ b/localgov_microsites.install
@@ -5,12 +5,54 @@
  * Install functions for the LocalGov Microsites installation profile.
  */
 
+use Drupal\user\Entity\Role;
+
+/**
+ * Implements hook_install().
+ */
+function localgov_microsites_install() {
+  // Allow microsites controllers and editors to use redirect module.
+  $role_names = [
+    'microsites_controller',
+    'microsites_trusted_editor',
+  ];
+
+  // Set 'administer redirects' permission for microsite controllers and editors.
+  foreach ($role_names as $role_name) {
+    $role = Role::load($role_name);
+    $role->grantPermission('administer redirects');
+    $role->save();
+  }
+}
+
 /**
  * Enable stable9 theme if localgov_base theme is enabled.
  */
 function localgov_update_9501() {
-
   if (\Drupal::service('theme_handler')->themeExists('localgov_base')) {
     \Drupal::service('theme_installer')->install(['stable9']);
+  }
+}
+
+/**
+ * Enable redirect module and set 'administer redirects' permission.
+ */
+function localgov_microsites_update_10001() {
+  // Enable redirect module if it is not already enabled.
+  $moduleHandler = \Drupal::service('module_handler');
+  if (!$moduleHandler->moduleExists('redirect')) {
+    \Drupal::service('module_installer')->install(['redirect']);
+  }
+
+  // Set 'administer redirects' permission for microsite controllers and editors.
+  $role_names = [
+    'microsites_controller',
+    'microsites_trusted_editor',
+  ];
+
+  foreach ($role_names as $role_name) {
+    $role = Role::load($role_name);
+    $role->grantPermission('administer redirects');
+    $role->save();
   }
 }


### PR DESCRIPTION
Closes #445 

- Adds redirect to composer.json (it will soon be missing since it's removed from localgov_core
- Enables redirect module
- Allows controllers and editors to use redirect