### PR TITLE
202407 responsive preview

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "drupal/gin_toolbar": "^1.0@RC",
         "drupal/metatag": "^1.22",
         "drupal/redirect": "^1.9",
+        "drupal/responsive_preview": "^2.1",
         "localgovdrupal/localgov_blogs": "^1.0.0-beta3",
         "localgovdrupal/localgov_core": "^2.12",
         "localgovdrupal/localgov_directories": "^3.0@alpha",

--- a/localgov_microsites.info.yml
+++ b/localgov_microsites.info.yml
@@ -47,6 +47,7 @@ install:
   - metatag:metatag_twitter_cards
   - require_login:require_login
   - redirect:redirect
+  - responsive_preview:responsive_preview
   - twig_tweak:twig_tweak
 
   # LocalGov Drupal


### PR DESCRIPTION
Adds drupal/responsive_preview as a dependency of Microsites
enables it by default

NB I did not know how to fully test the composer part of this.
Site install works a treat once the module is in place in /modules/contrib.
Default config works.

Issue: https://github.com/localgovdrupal/localgov_microsites/issues/444