### PR TITLE
feat: update metatag to recommended release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "drupal/gin": "^3.0@RC",
         "drupal/gin_login": "^2.0",
         "drupal/gin_toolbar": "^1.0@RC",
-        "drupal/metatag": "^1.22",
+        "drupal/metatag": "^2.0.2",
         "drupal/redirect": "^1.9",
         "drupal/responsive_preview": "^2.1",
         "localgovdrupal/localgov_blogs": "^1.0.0-beta3",


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

I couldn't work out why coding standards failed on https://github.com/localgovdrupal/localgov_microsites_project/actions/runs/11678582582/job/32518280525 and localgov_news stays at 2.3.8 and doesn't go to 2.3.10.

After having some free time it turns out it was because metatag is using version 1 and not set to the latest recommended release, version 2 (https://www.drupal.org/project/metatag).

metatag is also in https://github.com/localgovdrupal/localgov_core/blob/2.x/composer.json#L13 so there is a question around whether we just remove it from the profile as we already include localgov_core as a dependency