### PR TITLE
Make register account admin only

### DIFF
--- a/config/install/user.settings.yml
+++ b/config/install/user.settings.yml
@@ -10,7 +10,7 @@ notify:
   register_admin_created: true
   register_no_approval_required: true
   register_pending_approval: true
-register: visitors_admin_approval
+register: admin_only
 cancel_method: user_cancel_block
 password_reset_timeout: 86400
 password_strength: true


### PR DESCRIPTION
By default any visitor to the site can register for an account
![Image](https://github.com/user-attachments/assets/1887f694-aa5f-44bb-945e-1c89f57d9174)

For security reasons I think this should be set to Administrators only
![image](https://github.com/user-attachments/assets/d5f6282f-6564-45db-9878-bd0de39fae5a)
