### PR TITLE
Patch: Undefined array key 'pathauto' no longer applies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "drupal/autosave_form": "^1.3",
         "drupal/core": "^10.0",
         "drupal/default_content": "^2.0@alpha",
-        "drupal/domain_path": "^1.2",
+        "drupal/domain_path": "^1.5",
         "drupal/gin": "^3.0@RC",
         "drupal/gin_login": "^2.0",
         "drupal/gin_toolbar": "^1.0@RC",
@@ -50,8 +50,7 @@
         },
         "patches": {
             "drupal/domain_path": {
-                "https://github.com/localgovdrupal/localgov_microsites/pull/175#issuecomment-1172879196": "https://raw.githubusercontent.com/localgovdrupal/localgov_microsites/995261d0909065e3124fba3fc0dce3e823aefa1d/patches/domain_path.146-url-aliases.patch",
-                "https://github.com/localgovdrupal/localgov_microsites_group/issues/326": "https://raw.githubusercontent.com/localgovdrupal/localgov_microsites/4cbdbe6ae3c3e95e7d2ed15d918c66805ad8e7f1/patches/localgov_microsites_group_326.domain_path_pathauto.unserializable.patch"
+                "https://github.com/localgovdrupal/localgov_microsites/pull/175#issuecomment-1172879196": "https://raw.githubusercontent.com/localgovdrupal/localgov_microsites/995261d0909065e3124fba3fc0dce3e823aefa1d/patches/domain_path.146-url-aliases.patch"
             }
         }
     }


### PR DESCRIPTION
Removing `domain_path` patch `"Warning: Undefined array key 'pathauto' #3315752": "https://www.drupal.org/files/issues/2022-10-17/undefined-array-key-pathauto-3265497-2.patch"` and bumping `domain_path` version to 1.5

See issue: https://github.com/localgovdrupal/localgov_microsites/issues/513
