### PR TITLE
Specify microsites base 2 or 3 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "localgovdrupal/localgov_events": "^3.0",
         "localgovdrupal/localgov_live_preview": "^1.0.0-beta1",
         "localgovdrupal/localgov_microsites_group": "^4.0",
-        "localgovdrupal/localgov_microsites_base": "^2.0",
+        "localgovdrupal/localgov_microsites_base": "^2.0 || ^3.0",
         "localgovdrupal/localgov_microsites_colour_picker_fields": "^1.0.0-beta1",
         "localgovdrupal/localgov_news": "^2.3",
         "localgovdrupal/localgov_page": "^1.0.0-beta2",


### PR DESCRIPTION
Closes https://github.com/localgovdrupal/localgov_microsites/issues/530

Prepared this constraint for release of 3.x.