### PR TITLE
adds guides to microsites

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "localgovdrupal/localgov_core": "^2.12",
         "localgovdrupal/localgov_directories": "^3.1",
         "localgovdrupal/localgov_events": "^3.0",
+        "localgovdrupal/localgov_guides": "^2.1",
         "localgovdrupal/localgov_live_preview": "^1.0.0-beta1",
         "localgovdrupal/localgov_microsites_group": "^4.0",
         "localgovdrupal/localgov_microsites_base": "^2.0 || ^3.0",


### PR DESCRIPTION
Closes #476 

## What does this change?

Adds the LocalGov Guides package to Microsites. This will not add the content type to by used within microsites, it's only adding the guides module.

To get the functionality, you will also need [the (new) submodule in LocalGov Microsites Group](https://github.com/localgovdrupal/localgov_microsites_group/pull/552).

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.