### PR TITLE
Adds Step-by-Step to Microsites

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "localgovdrupal/localgov_page": "^1.0.0-beta2",
         "localgovdrupal/localgov_claro": "^2.1.0",
         "localgovdrupal/localgov_sa11y": "^1.0.0-beta1",
+        "localgovdrupal/localgov_step_by_step": "^2.1",
         "drupal/require_login": "^3.0"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Closes #518 

## What does this change?

Adds the LocalGov Step-by-Step package to Microsites. This will not add the content type to by used within microsites, it's only adding the step-by-step module.

To get the functionality, you will also need [the (new) submodule in LocalGov Microsites Group](https://github.com/localgovdrupal/localgov_microsites_group/pull/554).

---

Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.