### PR TITLE
adds publications to microsites

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "localgovdrupal/localgov_news": "^2.3",
         "localgovdrupal/localgov_page": "^1.0.0-beta2",
         "localgovdrupal/localgov_claro": "^2.1.0",
+        "localgovdrupal/localgov_publications": "^1.0",
         "localgovdrupal/localgov_sa11y": "^1.0.0-beta1",
         "drupal/require_login": "^3.0"
     },


### PR DESCRIPTION
Closes #475

## What does this change?

Adds the LocalGov publications package to Microsites. This will not add the content type to by used within microsites, it's only adding the publications module.

To get the functionality, you will also need the (new) submodule in LocalGov Microsites Group.

---

Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.